### PR TITLE
Add support for Mandrill subaccounts

### DIFF
--- a/src/MandrillAdapter.php
+++ b/src/MandrillAdapter.php
@@ -94,7 +94,7 @@ class MandrillAdapter extends BaseTransportAdapter
                 ]
             ],
             'apiKey' => $this->apiKey,
-            'subAccount' => $this->subaccount,
+            'subAccount' => $this->subaccount ?: null,
         ];
     }
 }

--- a/src/MandrillAdapter.php
+++ b/src/MandrillAdapter.php
@@ -45,7 +45,7 @@ class MandrillAdapter extends BaseTransportAdapter
     /**
      * @var string The subaccount that should be used
      */
-    public $subAccount;
+    public $subaccount;
 
     // Public Methods
     // =========================================================================
@@ -57,7 +57,7 @@ class MandrillAdapter extends BaseTransportAdapter
     {
         return [
             'apiKey' => Craft::t('mandrill', 'API Key'),
-            'subAccount' => Craft::t('mandrill', 'Subaccount'),
+            'subaccount' => Craft::t('mandrill', 'Subaccount'),
         ];
     }
 
@@ -94,7 +94,7 @@ class MandrillAdapter extends BaseTransportAdapter
                 ]
             ],
             'apiKey' => $this->apiKey,
-            'subAccount' => $this->subAccount,
+            'subaccount' => $this->subaccount,
         ];
     }
 }

--- a/src/MandrillAdapter.php
+++ b/src/MandrillAdapter.php
@@ -42,10 +42,10 @@ class MandrillAdapter extends BaseTransportAdapter
      */
     public $apiKey;
 
-	/**
-	 * @var string The subaccount that should be used
-	 */
-	public $subAccount;
+    /**
+     * @var string The subaccount that should be used
+     */
+    public $subAccount;
 
     // Public Methods
     // =========================================================================
@@ -94,7 +94,7 @@ class MandrillAdapter extends BaseTransportAdapter
                 ]
             ],
             'apiKey' => $this->apiKey,
-	        'subAccount' => $this->subAccount,
+            'subAccount' => $this->subAccount,
         ];
     }
 }

--- a/src/MandrillAdapter.php
+++ b/src/MandrillAdapter.php
@@ -94,7 +94,7 @@ class MandrillAdapter extends BaseTransportAdapter
                 ]
             ],
             'apiKey' => $this->apiKey,
-            'subaccount' => $this->subaccount,
+            'subAccount' => $this->subaccount,
         ];
     }
 }

--- a/src/MandrillAdapter.php
+++ b/src/MandrillAdapter.php
@@ -42,6 +42,11 @@ class MandrillAdapter extends BaseTransportAdapter
      */
     public $apiKey;
 
+	/**
+	 * @var string The subaccount that should be used
+	 */
+	public $subAccount;
+
     // Public Methods
     // =========================================================================
 
@@ -52,6 +57,7 @@ class MandrillAdapter extends BaseTransportAdapter
     {
         return [
             'apiKey' => Craft::t('mandrill', 'API Key'),
+            'subAccount' => Craft::t('mandrill', 'Subaccount'),
         ];
     }
 
@@ -88,6 +94,7 @@ class MandrillAdapter extends BaseTransportAdapter
                 ]
             ],
             'apiKey' => $this->apiKey,
+	        'subAccount' => $this->subAccount,
         ];
     }
 }

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -8,3 +8,12 @@
     value: adapter.apiKey,
     errors: adapter.getErrors('apiKey')
 }) }}
+
+{{ forms.textField({
+    label: "Subaccount"|t('mandrill'),
+    instructions: "You can find this in your Mandrill settings."|t('mandrill'),
+    id: 'subAccount',
+    name: 'subAccount',
+    value: adapter.subAccount,
+    errors: adapter.getErrors('subAccount')
+}) }}

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -12,8 +12,8 @@
 {{ forms.textField({
     label: "Subaccount"|t('mandrill'),
     instructions: "You can find this in your Mandrill settings."|t('mandrill'),
-    id: 'subAccount',
-    name: 'subAccount',
-    value: adapter.subAccount,
-    errors: adapter.getErrors('subAccount')
+    id: 'subaccount',
+    name: 'subaccount',
+    value: adapter.subaccount,
+    errors: adapter.getErrors('subaccount')
 }) }}

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -11,7 +11,7 @@
 
 {{ forms.textField({
     label: "Subaccount"|t('mandrill'),
-    instructions: "You can find this in your Mandrill settings."|t('mandrill'),
+    instructions: "If you want to send mail using a [subaccount], enter its unique identifier here."|t('mandrill')~"\n\n[subaccount]: https://mandrill.zendesk.com/hc/en-us/articles/205583357-About-Subaccounts",
     id: 'subaccount',
     name: 'subaccount',
     value: adapter.subaccount,


### PR DESCRIPTION
Mandrill has the concept of [subaccounts](https://mandrill.zendesk.com/hc/en-us/articles/205583357-About-Subaccounts) to separate out different types of users/clients/projects. 
The `accord/mandrill-swiftmailer` this plugin uses supports subaccounts so I thought I'd add a setting for them.

(Not sure how widely used this is or if this should be in the general Mandrill plugin, if not I'll happily make a separate plugin with this in it)

Cheers
Jan